### PR TITLE
Update for community/virtual events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # GETconf 2019 Code of Conduct
 GETconf is dedicated to providing a harassment-free experience for everyone; regardless of gender identity and/or expression, sexual orientation, ability status, physical appearance, race, age or religion. We do not tolerate harassment of conference participants in any form.
 ### [Core Values](#core-values)
-- We are a conference created by and centering women, femmes, and gender-expansive individuals
+- We are a community and series of events created by and centering women, femmes, and gender-expansive individuals
 - We offer education, networking, & mentorship, in a diversely tech-centered environment
-- We commit to making this conference accessible & inclusive to ALL
+- We commit to making this community accessible & inclusive to ALL
 ### [Enforcement](#enforcement)
-ALL involved parties (exhibitors, sponsor/venue staff, vendors, or volunteers) are expected to comply with GETconf expectations. We expect participants to follow these expectations at all event venues and event-related social activities.
-Event organisers retain the right to take necessary actions to keep the event a welcoming environment for ALL participants. This includes warning the offender or expulsion from the conference [with no refund].
+ALL involved parties (exhibitors, sponsor/venue staff, vendors, volunteers, and attendees) are expected to comply with GETconf expectations. We expect participants to follow these expectations at all event venues and event-related social activities.
+Organisers retain the right to take necessary actions to keep the community a welcoming environment for ALL participants. This includes warning the offender or expulsion from free or paid events [with no refund].
 ### [Reporting](#reporting)
 If someone makes you or anyone else feel unsafe or unwelcome, please report it as soon as possible. Reports can be made either personally or anonymously.
 **You can make a personal report by:**
-- Calling or messaging (402)786-8134. This phone number will be continuously monitored for the duration of the event.
-- Contacting a staff member, identified by STAFF badges, buttons, or shirts.
+- Calling or messaging (402)273-8472. This phone number will be continuously monitored for the duration of any GETconf event.
+- For in-person events, contacting a staff member, identified by STAFF badges, buttons, or shirts.
+- For virtual events, contacting a Host
 
 **Anonymous reports, are not available for direct follow-up, but we will fully investigate it and take whatever action is necessary to prevent a recurrence.*
 
@@ -26,4 +27,4 @@ If necessary, our team will be happy to help you contact hotel/venue security, l
 - Unwelcome sexual attention
 - Advocating for, or encouraging, any of the above behaviour
 
-Harassment and other code of conduct violations reduce the value of our event for everyone. 
+Harassment and other code of conduct violations reduce the value of our community and events for everyone. 


### PR DESCRIPTION
Updates copy to reflect that the GETconf CoC covers more than just the conference, but also any virtual events (ex: the upcoming happy hour), and future ongoing community events (ex: hypothetical book club)